### PR TITLE
Add tracking for amulet of avarice to skull timer

### DIFF
--- a/src/main/java/com/skulltimer/EquipmentChecker.java
+++ b/src/main/java/com/skulltimer/EquipmentChecker.java
@@ -1,0 +1,100 @@
+package com.skulltimer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+
+/**
+ * A class that is used to check a players worn equipment to identify if a skull timer is required.
+ * <pr> This feature is based on the suggestion and code provided by @juusokarjanlahti (<a href="https://github.com/juusokarjanlahti">GitHub</a>).</pr>
+ */
+@Slf4j
+public class EquipmentChecker
+{
+	/** A {@link Boolean} value that is changed when a player equips an item which provides a skull (e.g. amulet of avarice). */
+	private boolean hasEquippedIndefiniteSkullItem = false;
+
+	/**
+	 * A method used to check if a timer should be started by checking for any equipment that would provide a skulled status.
+	 *
+	 * <p>
+	 * There are 5 possible states that the players equipment can be in:<br>
+	 * 1) {@code equipment} is null or the player is not wearing any matching equipment (returns {@code false}).<br>
+	 * 2) The player is wearing equipment that provides a skulled status indefinitely (returns {@code false}).<br>
+	 * 3) The player is wearing equipment that provides a skull immediately upon equipping. (returns {@code true}).<br>
+	 * 4) The player has previously worn indefinite skulled equipment but it has been unequipped. (returns {@code true}).<br>
+	 * 5) The player is wearing both permanent and temporary skulled items. (returns {@code false}).<br>
+	 * </p>
+	 * @param equipment An {@link ItemContainer} representing the equipment inventory.
+	 * @return A {@link Boolean} value to indicate whether a {@link SkulledTimer} should be started:
+	 * 		   {@code true} if a timer should be started (e.i. they are wearing or have worn equipment that provides a skull),
+	 * 		   {@code false} if a timer should not be started (i.e. the player is not wearing any corresponding equipment).
+	 */
+	public boolean hasEquipmentChanged(ItemContainer equipment)
+	{
+		// Ensure the equipment is not null (e.g., during loading screens)
+		if (equipment == null) {
+			log.debug("Equipment is null.");
+			return false;
+		}
+
+		boolean itemCheck = isWearingSkulledItem(equipment);
+
+		// Player is wearing no items
+		if (!itemCheck) {
+			if (hasEquippedIndefiniteSkullItem) {
+				log.debug("Skulled item unequipped. Starting 20-minute skull timer.");
+				setHasEquippedIndefiniteSkullItem(false);
+				return true;
+			}
+			return false;
+		}
+
+		// Player is wearing no permanent items
+		return !hasEquippedIndefiniteSkullItem;
+	}
+
+	/**
+	 * A method to identify if the player is wearing any armour that would provide a skulled status.
+	 * @param equipment An {@link ItemContainer} representing the equipment inventory.
+	 * @return A {@link Boolean} value to indicate if the player is wearing any armour that provides a skull:
+	 * 			{@code true} if the player is wearing any matching armour in {@link SkulledItems},
+	 * 			{@code false} if not.
+	 */
+	public boolean isWearingSkulledItem(ItemContainer equipment)
+	{
+		// Ensure the equipment is not null (e.g., during loading screens)
+		if (equipment == null) {
+			return false;
+		}
+
+		//sort the items to make sure that permanent items are found first.
+		List<SkulledItems> sortedSkulledItems = Arrays.stream(SkulledItems.values())
+			.sorted((item1, item2) -> Boolean.compare(item2.isSkullIndefinite(), item1.isSkullIndefinite()))
+			.collect(Collectors.toList());
+
+		//first check for permanent
+		for (SkulledItems skulledItem : sortedSkulledItems) {
+			Item containerItem = equipment.getItem(skulledItem.getItemSlot());
+			//if the worn item matches a skulled item and if it matches the required check.
+			if (containerItem != null && containerItem.getId() == skulledItem.getItemID()) {
+				setHasEquippedIndefiniteSkullItem(skulledItem.isSkullIndefinite());
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * A method that is used to set the value of {@code hasEquippedIndefiniteSkullItem}.
+	 * @param value The {@link Boolean} value to update {@code hasEquippedIndefiniteSkullItem} to.
+	 */
+	private void setHasEquippedIndefiniteSkullItem(boolean value){
+		log.debug("Setting equipped items value to {}.", value);
+		hasEquippedIndefiniteSkullItem = value;
+	}
+}

--- a/src/main/java/com/skulltimer/SkulledItems.java
+++ b/src/main/java/com/skulltimer/SkulledItems.java
@@ -1,0 +1,27 @@
+package com.skulltimer;
+
+import lombok.Getter;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.ItemID;
+
+/**
+ * An enumeration of items that provide skull statues when equipped.
+ */
+@Getter
+public enum SkulledItems
+{
+	AMULET_OF_AVARICE(ItemID.AMULET_OF_AVARICE, EquipmentInventorySlot.AMULET.getSlotIdx(), true),
+	CAPE_OF_SKULLS(ItemID.CAPE_OF_SKULLS, EquipmentInventorySlot.CAPE.getSlotIdx(), false);
+
+	private final int itemID;
+	private final int itemSlot;
+	/** A {@link Boolean} to check if the item provides a skull for an unlimited amount of time while equipped. */
+	private final boolean isSkullIndefinite;
+
+	SkulledItems(int itemID, int itemSlot, boolean isSkullIndefinite){
+		this.itemID = itemID;
+		this.itemSlot = itemSlot;
+		this.isSkullIndefinite = isSkullIndefinite;
+	}
+
+}

--- a/src/main/java/com/skulltimer/SkulledTimer.java
+++ b/src/main/java/com/skulltimer/SkulledTimer.java
@@ -43,8 +43,7 @@ public class SkulledTimer extends Timer
 
 	public Duration getRemainingTime()
 	{
-		Duration remainingTime = Duration.between(Instant.now(), getEndTime());
-		return remainingTime;
+		return Duration.between(Instant.now(), getEndTime());
 	}
 
 	public Color getTextColor()


### PR DESCRIPTION
I re-skull using Amulet of Avarice at the bank and lose track when the skull will expire.

The plugin only tracks skull timers acquired from Emblem Traders. I wanted to also track the timer for Amulet of Avarice.

When player equips Amulet of Avarice the skull timer infobox is set to 20 minutes, when it's unequipped it starts counting down.

![image](https://github.com/user-attachments/assets/2eb3f375-1509-4f77-bdb2-089b2adac335)

https://github.com/user-attachments/assets/5655f68c-25e0-4878-97f0-9c83d6494939


